### PR TITLE
fix: node limit of 25 for LB backend service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 rackspace-cloud-controller-manager
+vendor/

--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,6 @@ require (
 replace (
 	github.com/gophercloud/gophercloud => github.com/platform9/gophercloud v0.0.0-20230725192123-f5bf8afaa214
 	github.com/gophercloud/utils => github.com/platform9/gophercloud-utils v0.0.0-20230725192416-bb0e57cadb96
-	github.com/os-pc/gocloudlb => github.com/rackspace-spot/gocloudlb v0.0.0-20250805033408-726ea5832e03
+	github.com/os-pc/gocloudlb => github.com/rackspace-spot/gocloudlb v0.0.0-20250930033245-e5d4ec55705a
 	k8s.io/cloud-provider => github.com/platform9/k8s-cloud-provider v0.0.0-20230630054839-fab92f8cbf80
 )

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
-github.com/rackspace-spot/gocloudlb v0.0.0-20250805033408-726ea5832e03 h1:NIILQljs7JERnvUzLAT9gyLWmI0P/tHsB3WWVaXpSkw=
-github.com/rackspace-spot/gocloudlb v0.0.0-20250805033408-726ea5832e03/go.mod h1:vCN4JD8GTX/YkdqM3FVBtGBuHwJdC8ZRcJJHllq6qas=
+github.com/rackspace-spot/gocloudlb v0.0.0-20250930033245-e5d4ec55705a h1:D7QbSgNBpSxXcZ0OGCIvevqMWW+WyhM0UryxOadJQ/w=
+github.com/rackspace-spot/gocloudlb v0.0.0-20250930033245-e5d4ec55705a/go.mod h1:vCN4JD8GTX/YkdqM3FVBtGBuHwJdC8ZRcJJHllq6qas=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -469,7 +469,7 @@ func (lbaas *CloudLb) ensureLoadBalancerNodes(lbID uint64, port corev1.ServicePo
 
 	// Delete obsolete nodes for this pool
 	for _, node := range memberNodes {
-		klog.V(4).Infof("Deleting obsolete node %d for loadbalancer %s address %s", node.ID, lbID, node.Address)
+		klog.V(4).Infof("Deleting obsolete node %d for loadbalancer %d address %s", node.ID, lbID, node.Address)
 		err := lbnodes.Delete(lbaas.lb, lbID, node.ID).ExtractErr()
 		if err != nil && !cpoerrors.IsNotFound(err) {
 			return fmt.Errorf("error deleting obsolete node %d for load balancer %d address %s: %v", node.ID, lbID, node.Address, err)

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -488,9 +488,11 @@ func (lbaas *CloudLb) ensureLoadBalancerNodes(lbID uint64, port corev1.ServicePo
 
 	allowedToAdd := MaxNodeLimit - len(memberNodes)
 	if allowedToAdd < 0 {
+		klog.V(2).Infof("Load balancer %d already has maximum number of nodes %d, nothing to add.", lbID, MaxNodeLimit)
 		allowedToAdd = 0
 	}
 	if allowedToAdd < len(addNodes) {
+		klog.V(2).Infof("Load balancer %d has %d nodes, can only add %d more nodes to reach the maximum of %d nodes.", lbID, len(memberNodes), allowedToAdd, MaxNodeLimit)
 		addNodes = addNodes[:allowedToAdd]
 	}
 

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -495,7 +495,7 @@ func (lbaas *CloudLb) ensureLoadBalancerNodes(lbID uint64, port corev1.ServicePo
 	}
 
 	if len(addNodes) > 0 {
-		klog.V(4).Infof("Adding %s nodes to load balancer %d", len(addNodes), lbID)
+		klog.V(4).Infof("Adding %d nodes to load balancer %d", len(addNodes), lbID)
 		_, createErr := lbnodes.Create(lbaas.lb, lbID, addNodes).Extract()
 		if createErr != nil {
 			return fmt.Errorf("error adding nodes to load balancer: %d, %v", lbID, createErr)

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -20,6 +20,7 @@ package openstack
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -78,7 +79,7 @@ const (
 	ServiceAnnotationLoadBalancerEnableHealthMonitor = "loadbalancer.openstack.org/enable-health-monitor"
 
 	DefaultBatch = 10
-	NodeLimit    = 25
+	MaxNodeLimit = 25
 )
 
 // CloudLb is a LoadBalancer implementation for Rackspace Cloud LoadBalancer API
@@ -430,6 +431,16 @@ func (lbaas *CloudLb) ensureLoadBalancerNodes(lbID uint64, port corev1.ServicePo
 		return fmt.Errorf("error getting load balancer nodes %d: %v", lbID, err)
 	}
 	var addNodes []lbnodes.CreateOpts
+
+	// if we have more than MaxNodeLimit nodes, sort them by name to have a consistent order
+	if len(nodes) > MaxNodeLimit {
+		klog.V(2).Infof("More than %d nodes, sorting nodes by name to have a consistent order", MaxNodeLimit)
+		// sort nodes based on node name to have a consistent order
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[i].Name < nodes[j].Name
+		})
+	}
+
 	for _, node := range nodes {
 		addr, err := nodeAddressForLB(node)
 		if err != nil {
@@ -456,13 +467,35 @@ func (lbaas *CloudLb) ensureLoadBalancerNodes(lbID uint64, port corev1.ServicePo
 		}
 	}
 
-	if len(addNodes) > 25 {
-		klog.V(2).Infof("Load balancer %d: number of nodes to add %d exceeds %d, picking first %d nodes to add", lbID, len(addNodes), NodeLimit, NodeLimit)
-		addNodes = addNodes[:NodeLimit]
+	// Delete obsolete nodes for this pool
+	for _, node := range memberNodes {
+		klog.V(4).Infof("Deleting obsolete node %d for loadbalancer %s address %s", node.ID, lbID, node.Address)
+		err := lbnodes.Delete(lbaas.lb, lbID, node.ID).ExtractErr()
+		if err != nil && !cpoerrors.IsNotFound(err) {
+			return fmt.Errorf("error deleting obsolete node %d for load balancer %d address %s: %v", node.ID, lbID, node.Address, err)
+		}
+		provisioningStatus, err := waitLoadbalancerActiveStatus(lbaas.lb, lbID)
+		if err != nil {
+			return fmt.Errorf("timeout when waiting for loadbalancer to be ACTIVE after deleting member, current provisioning status %s", provisioningStatus)
+		}
+	}
+
+	// Re-fetch current members after deletion
+	memberNodes, err = getNodesByLBID(lbaas.lb, lbID)
+	if err != nil && !cpoerrors.IsNotFound(err) {
+		return fmt.Errorf("error getting load balancer nodes after deletion %d: %v", lbID, err)
+	}
+
+	allowedToAdd := MaxNodeLimit - len(memberNodes)
+	if allowedToAdd < 0 {
+		allowedToAdd = 0
+	}
+	if allowedToAdd < len(addNodes) {
+		addNodes = addNodes[:allowedToAdd]
 	}
 
 	if len(addNodes) > 0 {
-		klog.V(4).Infof("Adding nodes to load balancer %d", lbID)
+		klog.V(4).Infof("Adding %s nodes to load balancer %d", len(addNodes), lbID)
 		_, createErr := lbnodes.Create(lbaas.lb, lbID, addNodes).Extract()
 		if createErr != nil {
 			return fmt.Errorf("error adding nodes to load balancer: %d, %v", lbID, createErr)
@@ -477,19 +510,6 @@ func (lbaas *CloudLb) ensureLoadBalancerNodes(lbID uint64, port corev1.ServicePo
 	}
 
 	klog.V(4).Infof("Ensured load balancer %d has member nodes", lbID)
-
-	// Delete obsolete nodes for this pool
-	for _, node := range memberNodes {
-		klog.V(4).Infof("Deleting obsolete node %d for loadbalancer %s address %s", node.ID, lbID, node.Address)
-		err := lbnodes.Delete(lbaas.lb, lbID, node.ID).ExtractErr()
-		if err != nil && !cpoerrors.IsNotFound(err) {
-			return fmt.Errorf("error deleting obsolete node %d for load balancer %d address %s: %v", node.ID, lbID, node.Address, err)
-		}
-		provisioningStatus, err := waitLoadbalancerActiveStatus(lbaas.lb, lbID)
-		if err != nil {
-			return fmt.Errorf("timeout when waiting for loadbalancer to be ACTIVE after deleting member, current provisioning status %s", provisioningStatus)
-		}
-	}
 
 	return nil
 }

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -78,6 +78,7 @@ const (
 	ServiceAnnotationLoadBalancerEnableHealthMonitor = "loadbalancer.openstack.org/enable-health-monitor"
 
 	DefaultBatch = 10
+	NodeLimit    = 25
 )
 
 // CloudLb is a LoadBalancer implementation for Rackspace Cloud LoadBalancer API
@@ -453,6 +454,11 @@ func (lbaas *CloudLb) ensureLoadBalancerNodes(lbID uint64, port corev1.ServicePo
 			klog.V(6).Infof("%s:%d is part of load balancer %d", addr, port.NodePort, lbID)
 			memberNodes = popNode(memberNodes, addr, int(port.NodePort))
 		}
+	}
+
+	if len(addNodes) > 25 {
+		klog.V(2).Infof("Load balancer %d: number of nodes to add %d exceeds %d, picking first %d nodes to add", lbID, len(addNodes), NodeLimit, NodeLimit)
+		addNodes = addNodes[:NodeLimit]
 	}
 
 	if len(addNodes) > 0 {


### PR DESCRIPTION
This PR is to address the Maximum node limit for the Load Balancer service in Rackspace LB v1. Please refer this [link](https://docs-ospc.rackspace.com/cloud-load-balancers/v1/api-reference/nodes.html#update-nodes) for documentation.

Attached the test log for a LB service.
[lb_test.log](https://github.com/user-attachments/files/22610210/lb_test.log)
